### PR TITLE
translate: rfc2495

### DIFF
--- a/text/2495-min-rust-version.md
+++ b/text/2495-min-rust-version.md
@@ -21,17 +21,17 @@ rust = "1.30"
 # 動機
 [動機]: #動機
 
-當前 crate 無任何正式方法指定 MSRV，導致使用者無法在不建構該 crate 的情況下得知 crate 是否可透過他們的工具鏈（toolchain）建構。這也帶來有關如何在提升 MSRV 時管理 crate 版本的爭論，保守的作法是將之視為破壞性改動，這種作法會阻礙整個生態採納新功能，或使得版本號通膨式提升，進而讓下游的 crate 很難跟上。另一方面，若作法稍微寬鬆些，則導致採用較舊編譯器版本的使用者弄壞它們的 crate。
+當前 crate 無任何正式方法指定 MSRV，導致使用者無法在不建構該 crate 的情況下得知 crate 是否可透過他們的工具鏈（toolchain）建構。這也帶來有關如何在提升 MSRV 時管理 crate 版本的爭論，保守的作法是將之視為破壞性改動，這種作法會阻礙整個生態採納新功能，或使得版本號通膨式提升，進而讓下游的 crate 很難跟上。另一方面，若作法稍微寬鬆些，則導致採用較舊編譯器版本的使用者無法成功編譯它們的 crate。
 
 # 教學式解說
 [教學式解說]: #教學式解說
 
-若你想指定一個特定 MSRV 版本，請在 `Cargo.toml` 的 `[package]` 區塊中的 `rust` 欄位設定指定的 Rust 版本。如果你建構一個 crate 時有任一依賴要求的 MSRV 比你當前工具鏈更高，會返回一個編譯錯誤，指明該依賴與它的 MSRV。這個行為可以透過 `--no-msrv-check` 旗標來停用。
+若你想指定一個特定 MSRV 版本，請在 `Cargo.toml` 的 `[package]` 區塊中的 `rust` 欄位設定指定的 Rust 版本。如果你建構一個 crate 時有任一依賴要求的 MSRV 比你當前工具鏈更高，會導致編譯錯誤，指明該依賴與它的 MSRV。這個行為可以透過 `--no-msrv-check` 選項來停用。
 
 # 技術文件式解說
 [技術文件式解說]: #技術文件式解說
 
-在建構過程（包含 `run`、`test`、`benchmark`、`verify` 與 `publish` 子指令），`cargo` 會以依賴樹（dependency tree）的形式，檢查所有將要建構或檢查的所有 crate 之 MSRV 要求。在依賴樹內但不會被構建的 crate 不會執行此此項檢查（例如特定目標平台或可選的 crate）。
+在建構過程（包含 `run`、`test`、`benchmark`、`verify` 與 `publish` 子指令），`cargo` 會以依賴樹（dependency tree）的形式，檢查所有將要建構或檢查的所有 crate 之 MSRV 要求。在依賴樹內但不會被構建的 crate 不會執行此項檢查（例如特定目標平台或可選的 crate）。
 
 `rust` 欄位應至少遵循下列要求：
 
@@ -61,7 +61,7 @@ rust = "1.30"
 
 ## 將 `rust` 欄位設為必填
 
-未來（可能是下一個 edition），我們可以設定新上傳的 crate 的 `rust` 欄位為必填。既有 crate 的 MSRV 會透過 `edition` 決定。換句話說 `edition = 2018` 必然是 `rust = "1.31"`，而 `edition = "2015"` 則代表 `rust = "1.0"`。
+未來（可能是下一個 edition），我們可以設定新上傳的 crate 的 `rust` 欄位為必填。既有 crate 的 MSRV 會透過 `edition` 決定。換句話說 `edition = 2018` 之 MSRV 必然是 `rust = "1.31"`，而 `edition = "2015"` 則是 `rust = "1.0"`。
 
 `cargo init` 將會使用當前工具鏈使用的版本。
 
@@ -82,13 +82,13 @@ rust = "1.33"
 
 在 `target` 區塊中所有 `rust` 值應等於或高於在 `package` 區塊的 `rust` 值。
 
-若目標的條件為真，`cargo` 會取用該區塊的 `rust` 值。若多個 target 區塊的條件為真，則取用最大值。
+若 `target` 的條件為真，`cargo` 會取用該區塊的 `rust` 值。若多個 target 區塊的條件為真，則取用最大值。
 
 ## Nightly 與 stable 版本
 
 部分 crate 可能偏好在最新 stable 或 nighly 工具鏈，除了指定版本之外，我們可允許宣告 `stable` 或 `nightly` 值，讓維護者不需追蹤該 crate 的 MSRV 。
 
-對於某些超前沿的 crate 常常因為 Nightly 更新就壞，將可指定特定可成功建構的 Nightly 版本。透過下列語法來達成：
+對於某些超前沿的 crate（例如： `rocket`）常常因為 Nightly 更新就壞，將可指定特定可成功建構的 Nightly 版本。透過下列語法來達成：
 
 - 自動選擇：`nightly` 此寫法與寫 `stable` 的行為一致，將使用等於當前或更高的 nightly 版本。
 - 單一版本：`nightly: 2018-01-01` （主要寫法）
@@ -108,7 +108,7 @@ rust = "1.33"
 [替代方案]: #替代方案
 
 - 自動計算 MSRV。
-- 不做，依靠 [LTS 發行](https://github.com/rust-lang/rfcs/pull/2483) 的 crate MSRV 提升。
+- 不做任何事，依靠 [LTS 發行](https://github.com/rust-lang/rfcs/pull/2483) 的 crate MSRV 提升。
 - 允許在 [RFC 2523](https://github.com/rust-lang/rfcs/pull/2523) 中提出基於版本與路徑的 `cfg` 屬性（attribute）
 
 # 先前技術
@@ -124,7 +124,7 @@ rust = "1.33"
 # 未解決問題
 [未解決問題]: #未解決問題
 
-- 單車棚式的命名問題：`rust` 或 `rustc` 還是 `min-rust-version`
+- 瑣碎的命名問題：`rust` 或 `rustc` 還是 `min-rust-version`
 - 額外的檢查？
 - 更優質地說明版本解析演算法
-- nightly 版本如何與 "cfg based MSRV" 互動？
+- nightly 版本如何與「基於 cfg 的 MSRV」運作？

--- a/text/2495-min-rust-version.md
+++ b/text/2495-min-rust-version.md
@@ -111,8 +111,8 @@ rust = "1.33"
 - 不做任何事，依靠 [LTS 發行](https://github.com/rust-lang/rfcs/pull/2483) 的 crate MSRV 提升。
 - 允許在 [RFC 2523](https://github.com/rust-lang/rfcs/pull/2523) 中提出基於版本與路徑的 `cfg` 屬性（attribute）
 
-# 先前技術
-[先前技術]: #先前技術
+# 先驅技術
+[先驅技術]: #先驅技術
 
 早先的提案：
 


### PR DESCRIPTION
Translate [rfc2495](https://rust-lang.github.io/rfcs/2495-min-rust-version.html). Feel free to discuss or rephrase anything weird.

---

[Rendered](https://github.com/weihanglo/rfcs-tw/blob/trans/rfc2495/text/2495-min-rust-version.md)